### PR TITLE
Limit messages to 20

### DIFF
--- a/api/app.js
+++ b/api/app.js
@@ -32,7 +32,14 @@ app.service('messages').before({
   }
 }).after({
   create: function(hook, next) {
-    
+    var keys = Object.keys(this.store);
+    if(keys.length > 20) {
+      this.remove(keys[0], function(error) {
+        next(error);
+      });
+    } else {
+      return next();
+    }
   }
 });
 


### PR DESCRIPTION
Makes the API delete an old message when a new one is added and there are more than 20.