### PR TITLE
Can6 upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,17 +43,17 @@
     ]
   },
   "dependencies": {
-    "bit-tabs": "^2.0.1",
+    "bit-tabs": "^v3.0.0-pre.0",
     "body-parser": "^1.15.0",
     "bootstrap": "^3.3.7",
-    "can": "^5.16.0",
+    "can": "^6.2.7",
     "can-route-pushstate": "^5.0.7",
-    "can-stache-route-helpers": "^1.1.1",
+    "can-stache-route-helpers": "^2.0.0",
     "can-zone": "^1.0.0",
-    "done-autorender": "^2.4.3",
-    "done-component": "^2.2.0",
+    "done-autorender": "^v3.0.0-pre.1",
+    "done-component": "^v3.0.0-pre.0 ",
     "done-css": "^3.0.2",
-    "done-serve": "^3.0.0-pre.3",
+    "done-serve": "^3.3.1",
     "express-ie-cors": "^0.9.4",
     "feathers": "^1.1.1",
     "feathers-hooks": "^0.5.1",
@@ -62,7 +62,7 @@
     "steal": "^2.1.6",
     "steal-less": "^1.2.2",
     "steal-socket.io": "^4.1.0",
-    "steal-stache": "^4.1.2"
+    "steal-stache": "^5.0.0"
   },
   "devDependencies": {
     "can-debug": "^2.0.1",

--- a/src/pages/home.component
+++ b/src/pages/home.component
@@ -16,13 +16,15 @@
     </h1>
 
     <bit-tabs tabsClass:raw="nav nav-tabs">
-      <bit-panel title:raw="CanJS">
-        <p>CanJS provides the MV*</p>
-      </bit-panel>
-      <bit-panel title:raw="StealJS">
-        <p>StealJS provides the infrastructure.</p>
-      </bit-panel>
-    </bit-tabs>
+      <can-template name="bitPanels">
+        <bit-panel title:raw="CanJS">
+          <can-template name="content"><p>CanJS provides the MV*</p></can-template>
+        </bit-panel>
+        <bit-panel title:raw="StealJS">
+          <can-template name="content"><p>StealJS provides the infrastructure.</p></can-template>
+        </bit-panel>
+      </can-template>
+	  </bit-tabs>
 
     <a href="{{routeUrl(page='chat')}}"
        class="btn btn-primary btn-block btn-lg">


### PR DESCRIPTION
Unfinished.

Working towards upgrading DoneJS 6 to CanJS 6 (using this project to get DoneJS' dependencies ready).

[DoneJS upgrade issue](https://github.com/donejs/donejs/issues/1198)